### PR TITLE
Added basic dart:io HttpClient support

### DIFF
--- a/src/targets/dart/httpclient/client.ts
+++ b/src/targets/dart/httpclient/client.ts
@@ -1,0 +1,30 @@
+import { CodeBuilder } from '../../../helpers/code-builder.js';
+import { Client } from '../../targets.js';
+
+export const httpclient: Client = {
+  info: {
+    key: 'httpclient',
+    title: 'HttpClient',
+    link: '',
+    description: 'dart:io default HTTP Client',
+  },
+  convert: ({ allHeaders, postData, method, fullUrl }, options) => {
+    const opts = {
+      indent: '    ',
+      ...options,
+    };
+
+    const { push, join } = new CodeBuilder({ indent: opts.indent });
+
+    push('import \'dart:io\';');
+    push('Future<void> main() async {');
+    push('final client = HttpClient();', 1);
+    push(`final request = client.${method.toLowerCase()}Url(${fullUrl})`, 1);
+    push('final response = await request.close();', 1);
+    push('final body = await response.transform(const Utf8Decoder()).join();', 1);
+    push('print(body);', 1);
+    push('}');
+
+    return join();
+  },
+};

--- a/src/targets/dart/target.ts
+++ b/src/targets/dart/target.ts
@@ -1,0 +1,14 @@
+import { Target } from '../targets.js';
+import { httpclient } from './httpclient/client.js';
+
+export const dart: Target = {
+  info: {
+    key: 'dart',
+    title: 'Dart',
+    extname: '.dart',
+    default: 'httpclient',
+  },
+  clientsById: {
+    httpclient,
+  },
+};

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -4,6 +4,7 @@ import { availableTargets } from '../httpsnippet.js';
 import { c } from './c/target.js';
 import { clojure } from './clojure/target.js';
 import { csharp } from './csharp/target.js';
+import { dart } from './dart/target.js';
 import { go } from './go/target.js';
 import { http } from './http/target.js';
 import { java } from './java/target.js';
@@ -64,6 +65,7 @@ export const targets = {
   c,
   clojure,
   csharp,
+  dart,
   go,
   http,
   java,


### PR DESCRIPTION
Hi, since there are no issues enabled for this repo, I wasn't able to ask if you want to add support for Dart snippets.

So I just went ahead and added a proof-of-concept. Do you want me to continue working on this?

Things like setting headers and request bodies is completely missing, let alone response encoding and so on...